### PR TITLE
Refactor formatName test

### DIFF
--- a/src/logic/formatName.test.ts
+++ b/src/logic/formatName.test.ts
@@ -1,23 +1,31 @@
 import { formatName } from './formatName';
 
 describe('formatName', () => {
-  it('should format correctly when name is string', () => {
-    expect(formatName('test')).toBe('test');
-  });
-
-  it('should format correctly when name is array', () => {
-    expect(formatName(['test1', 'test2'])).toBe('test1.test2');
-    expect(formatName(['test1', 'test2', 'test3'])).toBe('test1.test2.test3');
-    expect(formatName(['test1', 0, 'test2'])).toBe('test1[0].test2');
-    expect(formatName(['test1', 0, 'test2', 1, 'test3'])).toBe(
+  const tests: [string, string | [string, ...(string | number)[]], string][] = [
+    ['should format correctly when name is string', 'test', 'test'],
+    [
+      'should combine array to string like object if name is array when contain one item',
+      ['test1'],
+      'test1',
+    ],
+    [
+      'should combine array to string like object if name is array',
+      ['test1', 'test2', 'test3'],
+      'test1.test2.test3',
+    ],
+    [
+      'should combine array to string like array that contain object, if name is array when contain one item',
+      ['test1', 0],
+      'test1[0]',
+    ],
+    [
+      'should combine array to string like array that contain object, if name is array',
+      ['test1', 0, 'test2', 1, 'test3'],
       'test1[0].test2[1].test3',
-    );
-    expect(formatName(['test1', 'test2', 0, 'test3'])).toBe(
-      'test1.test2[0].test3',
-    );
-    expect(formatName(['test1', '0', 'test2'])).toBe('test1.0.test2');
-    expect(formatName(['test1', '0', 'test2', 1, 'test3'])).toBe(
-      'test1.0.test2[1].test3',
-    );
+    ],
+  ];
+
+  test.each(tests)('%s', (_, input, result) => {
+    expect(formatName(input)).toBe(result);
   });
 });


### PR DESCRIPTION
I reduced test case because there were duplicated tests. 
And I refactored test to use `test.each` method. Because this method's tests are simple and iterated same process.